### PR TITLE
Fix explosion particle

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinExplosion.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinExplosion.java
@@ -1,6 +1,8 @@
 package fi.dy.masa.tweakeroo.mixin;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import net.minecraft.particle.ParticleEffect;
@@ -11,16 +13,20 @@ import fi.dy.masa.tweakeroo.config.FeatureToggle;
 @Mixin(Explosion.class)
 public abstract class MixinExplosion
 {
+    @Shadow @Final private ParticleEffect particle;
+
+    @Shadow @Final private ParticleEffect emitterParticle;
+
     @ModifyArg(method = "affectWorld",
                at = @At(value = "INVOKE",
                target = "Lnet/minecraft/world/World;addParticle(Lnet/minecraft/particle/ParticleEffect;DDDDDD)V"))
-    private ParticleEffect addParticleModify(ParticleEffect parameters)
+    private ParticleEffect addParticleModify(ParticleEffect original)
     {
         if (FeatureToggle.TWEAK_EXPLOSION_REDUCED_PARTICLES.getBooleanValue())
         {
-            return ParticleTypes.EXPLOSION;
+            return particle;
         }
 
-        return ParticleTypes.EXPLOSION_EMITTER;
+        return original;
     }
 }


### PR DESCRIPTION
Mojang added new particles for wind charge explosions. However, the old code only support TNT explosions.