### PR TITLE
Fixed a bug in the `ConfigBooleanClient` class where the `getComment()` method was not functioning correctly

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/ConfigBooleanClient.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/ConfigBooleanClient.java
@@ -4,6 +4,8 @@ import fi.dy.masa.malilib.config.options.ConfigBooleanHotkeyed;
 import fi.dy.masa.malilib.gui.GuiBase;
 import fi.dy.masa.malilib.util.StringUtils;
 
+import java.util.Objects;
+
 public class ConfigBooleanClient extends ConfigBooleanHotkeyed
 {
     public ConfigBooleanClient(String name, boolean defaultValue, String defaultHotkey, String comment)
@@ -19,8 +21,8 @@ public class ConfigBooleanClient extends ConfigBooleanHotkeyed
     @Override
     public String getComment()
     {
-        String comment = super.getComment();
-
+//        String comment = super.getComment();
+        String comment = StringUtils.getTranslatedOrFallback(Objects.requireNonNull(super.getComment()), super.getComment());
         if (comment == null)
         {
             return "";


### PR DESCRIPTION
In the game, some comments are not displaying correctly, such as `tweakeroo.config.disable.comment.disableBatSpawning`. After reviewing the code, I found that `disableBatSpawning` uses the `ConfigBooleanClient` class, where the `getComment()` method is not functioning as expected. I made a fix, and it now works correctly.

In the game:
![before](https://github.com/user-attachments/assets/314d2fe7-66dd-46c5-b98b-84548cea3df5)

After fix:
![after](https://github.com/user-attachments/assets/d6d62e71-ace8-41d2-b68b-79daebd34858)


Could you please merge this PR into the 1.21 branch? Thanks a lot!