### PR TITLE
Add option to hide Camera Zoom Activated message

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
@@ -437,15 +437,21 @@ public class Callbacks
             {
                 if (action == KeyAction.PRESS)
                 {
-                    InfoUtils.printActionbarMessage("tweakeroo.message.toggled_zoom_activate_on",
-                            String.format("%s%.1f%s", GuiBase.TXT_GREEN, Configs.Generic.ZOOM_FOV.getDoubleValue(), GuiBase.TXT_RST));
+                    if (Configs.Generic.ZOOM_SHOW_MESSAGE_ON_PRESS.getBooleanValue())
+                    {
+                        InfoUtils.printActionbarMessage("tweakeroo.message.toggled_zoom_activate_on",
+                                String.format("%s%.1f%s", GuiBase.TXT_GREEN, Configs.Generic.ZOOM_FOV.getDoubleValue(), GuiBase.TXT_RST));
+                    }
                     MiscUtils.onZoomActivated();
                 }
                 else
                 {
                     MiscUtils.onZoomDeactivated();
-                    InfoUtils.printActionbarMessage("tweakeroo.message.toggled_zoom_activate_off",
-                            String.format("%s%.1f%s", GuiBase.TXT_GREEN, Configs.Generic.ZOOM_FOV.getDoubleValue(), GuiBase.TXT_RST));
+                    if (Configs.Generic.ZOOM_SHOW_MESSAGE_ON_PRESS.getBooleanValue())
+                    {
+                        InfoUtils.printActionbarMessage("tweakeroo.message.toggled_zoom_activate_off",
+                                String.format("%s%.1f%s", GuiBase.TXT_GREEN, Configs.Generic.ZOOM_FOV.getDoubleValue(), GuiBase.TXT_RST));
+                    }
                 }
             }
 

--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -122,6 +122,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBoolean       ZOOM_ADJUST_MOUSE_SENSITIVITY       = new ConfigBoolean     ("zoomAdjustMouseSensitivity", true, "tweakeroo.config.generic.comment.zoomAdjustMouseSensitivity").translatedName("tweakeroo.config.generic.name.zoomAdjustMouseSensitivity");
         public static final ConfigDouble        ZOOM_FOV                            = new ConfigDouble      ("zoomFov", 30, 0.01, 359.99, "tweakeroo.config.generic.comment.zoomFov").translatedName("tweakeroo.config.generic.name.zoomFov");
         public static final ConfigBoolean       ZOOM_RESET_FOV_ON_ACTIVATE          = new ConfigBoolean     ("zoomResetFovOnActivate", true, "tweakeroo.config.generic.comment.zoomResetFovOnActivate").translatedName("tweakeroo.config.generic.name.zoomResetFovOnActivate");
+        public static final ConfigBoolean       ZOOM_SHOW_MESSAGE_ON_PRESS          = new ConfigBoolean     ("zoomShowMessageOnPress", true, "tweakeroo.config.generic.comment.zoomShowMessageOnPress").translatedName("tweakeroo.config.generic.name.zoomShowMessageOnPress");
 
         public static final ImmutableList<IConfigBase> OPTIONS = ImmutableList.of(
                 ACCURATE_PLACEMENT_PROTOCOL_MODE,
@@ -211,7 +212,8 @@ public class Configs implements IConfigHandler
                 TOOL_SWAP_BETTER_ENCHANTS,
                 WEAPON_SWAP_BETTER_ENCHANTS,
                 ZOOM_FOV,
-                ZOOM_RESET_FOV_ON_ACTIVATE
+                ZOOM_RESET_FOV_ON_ACTIVATE,
+                ZOOM_SHOW_MESSAGE_ON_PRESS
         );
     }
 

--- a/src/main/resources/assets/tweakeroo/lang/en_us.json
+++ b/src/main/resources/assets/tweakeroo/lang/en_us.json
@@ -84,6 +84,7 @@
     "tweakeroo.config.generic.name.zoomAdjustMouseSensitivity": "zoomAdjustMouseSensitivity",
     "tweakeroo.config.generic.name.zoomFov": "zoomFov",
     "tweakeroo.config.generic.name.zoomResetFovOnActivate": "zoomResetFovOnActivate",
+    "tweakeroo.config.generic.name.zoomShowMessageOnPress": "zoomShowMessageOnPress",
 
     "tweakeroo.config.generic.comment.accuratePlacementProtocolMode": "The type of \"accurate placement protocol\" to use.\n- Auto: Uses v3 in single player, and by default Slabs-only in multiplayer,\n  unless the server has Carpet mod that sends a 'carpet:hello'\n  packet, in which case v2 is used on that server.\n- Version 3: Supported by Tweakeroo itself (in single player) or with Servux.\n- Version 2: Compatible with servers with the Carpet mod\n  (either QuickCarpet by skyrising and DeadlyMC,\n  or CarpetExtra in addition to FabricCarpet.\n  And in both cases the 'accurateBlockPlacement' Carpet rule needs\n  to be enabled on the server).\n- Slabs only: Only fixes top slabs. Compatible with Paper servers.\n- None: Does not modify coordinates.",
     "tweakeroo.config.generic.comment.accuratePlacementProtocol": "If enabled, then the Flexible Block Placement and the\nAccurate Block Placement use the protocol implemented in Carpet mod.\n§6Note: This is required for any block rotations to work, other than\n§6blocks that only care about the block side you click on (Hoppers, Logs etc.)",
@@ -170,6 +171,7 @@
     "tweakeroo.config.generic.comment.zoomAdjustMouseSensitivity": "If enabled, then the mouse sensitivity is reduced\nwhile the zoom feature is enabled and the zoom key is active",
     "tweakeroo.config.generic.comment.zoomFov": "The FOV value used for the zoom feature",
     "tweakeroo.config.generic.comment.zoomResetFovOnActivate": "Reset the Camera Zoom FOV upon Deactivation,\nif the Mouse Scroll Wheel was used to adjust it",
+    "tweakeroo.config.generic.comment.zoomShowMessageOnPress": "Show the 'Camera Zoom Activated' message in the action bar when pressing the zoom hotkey",
 
     "tweakeroo.config.fixes.name.elytraFix": "elytraFix",
     "tweakeroo.config.fixes.name.macHorizontalScroll": "macHorizontalScroll",


### PR DESCRIPTION
Adds an option to hide the "Camera Zoom Activated/Deactivated" message when pressing the zoom hotkey.
Minor change but the option to disable it is nice, especially with other mods that use the action bar for displaying information.