### PR TITLE
Fix Tweakeroo's free camera tweak breaking zoom mods

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinGameRenderer.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinGameRenderer.java
@@ -1,15 +1,15 @@
 package fi.dy.masa.tweakeroo.mixin;
 
 import java.util.function.Predicate;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.block.enums.CameraSubmersionType;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.At.Shift;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -51,10 +51,36 @@ public abstract class MixinGameRenderer
         {
             cir.setReturnValue((float) Configs.Generic.ZOOM_FOV.getDoubleValue());
         }
-        else if (FeatureToggle.TWEAK_FREE_CAMERA.getBooleanValue())
+    }
+
+    @ModifyExpressionValue(method = "getFov", at = @At(value = "CONSTANT", args = "floatValue=70.0"))
+    private float applyFreeCameraFov(float original)
+    {
+        if (FeatureToggle.TWEAK_FREE_CAMERA.getBooleanValue())
         {
-            cir.setReturnValue((float) this.client.options.getFov().getValue());
+            return ((float) this.client.options.getFov().getValue());
         }
+
+        return original;
+    }
+
+    @ModifyVariable(method = "getFov", at = @At(value = "LOAD", ordinal = 0), argsOnly = true)
+    private boolean freezeFovOnFreeCamera(boolean value)
+    {
+        return !FeatureToggle.TWEAK_FREE_CAMERA.getBooleanValue() && value;
+    }
+
+    @ModifyExpressionValue(
+            method = "getFov",  at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/client/render/Camera;getSubmersionType()Lnet/minecraft/block/enums/CameraSubmersionType;"))
+    private CameraSubmersionType ignoreSubmersionTypeOnFreeCamera(CameraSubmersionType original)
+    {
+        if (FeatureToggle.TWEAK_FREE_CAMERA.getBooleanValue())
+        {
+            return CameraSubmersionType.NONE;
+        }
+
+        return original;
     }
 
     @Redirect(method = "updateCrosshairTarget", at = @At(value = "INVOKE",


### PR DESCRIPTION
This puts a nail in the coffin of https://github.com/Up-Mods/OkZoomer/issues/48, https://github.com/isXander/Zoomify/issues/216, and really, *any* incompatibility issues involving Tweakeroo's free camera tweak and \<insert zoom mod that does things the proper way here\>; how hasn't this been dealt with here before?

Basically, zoom mods work in a straightforward way: they modify the internal FOV in a way or another (and if they don't and are modifying the game options' FOV, they are going to explode one day); Tweakeroo puts a halt on any attempts to do this while freecam is activated by uh, setting a value at head and cancelling the entire method, not even allowing for other mods to touch it;

This fixes the issue (with a little extra help from MixinExtras) by keeping the FOV as static as possible while also allowing for other mods' mixins to take effect; The end result? In a test instance, Ok Zoomer, Logical Zoom, Zoomify and Zume all can now successfully zoom while Free Camera is enabled, all while the base FOV remains static; heck, even three of these four mods can zoom together with no problems! (Logical Zoom unfortunately does it in a way that cannot stack with other changes)

I'd argue that this code could be further simplified considering that `getFovMultiplier` pretty much only takes effect if the camera entity is a client player (which the free camera is not), but you decide whenever to take that risk or not;

This is the only solution to the problem, there is no reasonable way a zoom mod can fix it itself; please consider this PR