### PR TITLE
fix: tweakMatchingSkyFog should only affect sky fog.

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/fog/MixinFogRenderer.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/fog/MixinFogRenderer.java
@@ -1,19 +1,13 @@
 package fi.dy.masa.tweakeroo.mixin.fog;
 
-import org.joml.Vector4f;
-
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.fog.FogRenderer;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.util.math.ColorHelper;
 import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.*;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import fi.dy.masa.tweakeroo.config.Configs;
-import fi.dy.masa.tweakeroo.config.FeatureToggle;
 
 @Mixin(FogRenderer.class)
 public class MixinFogRenderer
@@ -24,25 +18,6 @@ public class MixinFogRenderer
     private float tweakeroo_disableSkyDarkness(ClientWorld.Properties instance)
     {
         return Configs.Disable.DISABLE_SKY_DARKNESS.getBooleanValue() ? 1.0F : instance.getVoidDarknessRange();
-    }
-
-    @Inject(method = "getFogColor", at = @At("HEAD"), cancellable = true)
-    private void tweakeroo_adjustFogColor(Camera camera, float tickProgress, ClientWorld world, int viewDistance, float skyDarkness, boolean thick, CallbackInfoReturnable<Vector4f> cir)
-    {
-        if (FeatureToggle.TWEAK_MATCHING_SKY_FOG.getBooleanValue())
-        {
-            if (world.getDimension().hasSkyLight())
-            {
-                int color = world.getSkyColor(camera.getPos(), skyDarkness);
-
-                cir.setReturnValue(new Vector4f(
-                        ColorHelper.getRedFloat(color),
-                        ColorHelper.getGreenFloat(color),
-                        ColorHelper.getBlueFloat(color),
-                        ColorHelper.getAlphaFloat(color))
-                );
-            }
-        }
     }
 
     @ModifyConstant(method = "applyFog(Lnet/minecraft/client/render/Camera;IZLnet/minecraft/client/render/RenderTickCounter;FLnet/minecraft/client/world/ClientWorld;)Lorg/joml/Vector4f;",

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/fog/MixinStandardFogModifier.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/fog/MixinStandardFogModifier.java
@@ -1,0 +1,27 @@
+package fi.dy.masa.tweakeroo.mixin.fog;
+
+import fi.dy.masa.tweakeroo.config.FeatureToggle;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.fog.StandardFogModifier;
+import net.minecraft.client.world.ClientWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(StandardFogModifier.class)
+public class MixinStandardFogModifier {
+
+    @Inject(method = "getFogColor", at = @At("HEAD"), cancellable = true)
+    private void tweakeroo_adjustFogColor(ClientWorld world, Camera camera, int viewDistance, float skyDarkness, CallbackInfoReturnable<Integer> cir)
+    {
+        if (FeatureToggle.TWEAK_MATCHING_SKY_FOG.getBooleanValue())
+        {
+            if (world.getDimension().hasSkyLight())
+            {
+                int color = world.getSkyColor(camera.getPos(), skyDarkness);
+                cir.setReturnValue(color);
+            }
+        }
+    }
+}

--- a/src/main/resources/mixins.tweakeroo.json
+++ b/src/main/resources/mixins.tweakeroo.json
@@ -50,6 +50,7 @@
         "fog.MixinDarknessEffectFogModifier",
         "fog.MixinFogRenderer",
         "fog.MixinLavaFogModifier",
+        "fog.MixinStandardFogModifier",
         "fog.MixinWaterFogModifier",
         "freecam.MixinCamera_freeCam",
         "freecam.MixinClientPlayerEntity_freeCam",


### PR DESCRIPTION
Applies the matchingSkyFog color change to only StandardFog, so it doesn't affect fluid fog or blindness/darkness effects.