### PR TITLE
Allow movement from other mods in freecam

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/freecam/MixinClientPlayerEntity_freeCam.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/freecam/MixinClientPlayerEntity_freeCam.java
@@ -14,6 +14,7 @@ import fi.dy.masa.tweakeroo.util.CameraEntity;
 import fi.dy.masa.tweakeroo.util.CameraUtils;
 import fi.dy.masa.tweakeroo.util.DummyMovementInput;
 import net.minecraft.client.input.Input;
+import net.minecraft.client.input.KeyboardInput;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
@@ -35,7 +36,8 @@ public abstract class MixinClientPlayerEntity_freeCam extends AbstractClientPlay
     @Inject(method = "tick", at = @At("HEAD"))
     private void tweakeroo_disableMovementInputsPre(CallbackInfo ci)
     {
-        if (CameraUtils.shouldPreventPlayerMovement())
+        // Check if input is vanilla's keyboard input to allow other mods to move the player while in freecam
+        if (CameraUtils.shouldPreventPlayerMovement() && input.getClass() == KeyboardInput.class)
         {
             this.realInput = this.input;
             this.input = this.dummyMovementInput;


### PR DESCRIPTION
Does not change anything with only tweakeroo installed. Tested with baritone. For reference, they do the same [here](https://github.com/cabaletta/baritone/blob/6d5617ff620e2be9bf9428d935bcd5a54c72d339/src/main/java/baritone/utils/InputOverrideHandler.java#L96-L104).

I've tried to follow the code style. Please let me know if anything needs to be changed. Thanks.