### PR TITLE
Fix: ArrayIndexOutOfBoundsFix ArrayIndexOutOfBoundsException crash with Accessorify (Enum Extension)Exception with mods extending Hand enum

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
@@ -813,6 +813,14 @@ public class PlacementTweaks
             Vec3 hitVecIn,
             InteractionHand hand)
     {
+        // 修复mod拓展手的数量问题
+        // Fix for mods that extend the Hand enum (e.g. Accessorify/Accessories)
+        // causing ArrayIndexOutOfBoundsException because stackBeforeUse is hardcoded to size 2.
+        if (hand.ordinal() >= stackBeforeUse.length)
+        {
+            return ActionResult.PASS;
+        }
+
         //System.out.printf("processRightClickBlockWrapper() start @ %s, side: %s, hand: %s\n", posIn, sideIn, hand);
         if (FeatureToggle.TWEAK_PLACEMENT_LIMIT.getBooleanValue() &&
             placementCount >= Configs.Generic.PLACEMENT_LIMIT.getIntegerValue())


### PR DESCRIPTION
What does this PR do?
This PR adds a guard clause to PlacementTweaks.processRightClickBlockWrapper to prevent an ArrayIndexOutOfBoundsException when interacting with the world using a non-standard Hand (e.g., ACCESSORY_HAND).

Why is it needed?
Some mods, such as Accessorify (via the Accessories API), extend the vanilla Hand enum using Mixins. This introduces new Hand types with ordinal values >= 2.
Tweakeroo's stackBeforeUse array is hardcoded with a size of 2 (assuming only MAIN_HAND and OFF_HAND).
When a player interacts using the Accessory Hand, hand.ordinal() returns 2 (or higher), causing a crash when accessing stackBeforeUse[hand.ordinal()].
Crash Log Snippet:

java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at fi.dy.masa.tweakeroo.tweaks.PlacementTweaks.processRightClickBlockWrapper(PlacementTweaks.java:838)