### PR TITLE
set autoSwitchElytraChestplate to current chestplate when switching to elytra

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/entity/MixinClientPlayerEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/entity/MixinClientPlayerEntity.java
@@ -125,6 +125,7 @@ public abstract class MixinClientPlayerEntity extends AbstractClientPlayer
                 if (!this.getItemBySlot(EquipmentSlot.CHEST).is(Items.ELYTRA) ||
                     this.getItemBySlot(EquipmentSlot.CHEST).getDamageValue() > this.getItemBySlot(EquipmentSlot.CHEST).getMaxDamage() - 10)
                 {
+                    this.autoSwitchElytraChestplate = this.getItemBySlot(EquipmentSlot.CHEST);
                     InventoryUtils.equipBestElytra(this);
                 }
             }
@@ -154,6 +155,10 @@ public abstract class MixinClientPlayerEntity extends AbstractClientPlayer
                             if (targetSlot >= 0)
                             {
                                 InventoryUtils.swapItemToEquipmentSlot(this, EquipmentSlot.CHEST, targetSlot);
+                                this.autoSwitchElytraChestplate = ItemStack.EMPTY;
+                            } else {
+                                // cached item not found, try to swap to the default chest plate.
+                                InventoryUtils.swapElytraAndChestPlate(this);
                                 this.autoSwitchElytraChestplate = ItemStack.EMPTY;
                             }
                         }

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/entity/MixinClientPlayerEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/entity/MixinClientPlayerEntity.java
@@ -125,7 +125,7 @@ public abstract class MixinClientPlayerEntity extends AbstractClientPlayer
                 if (!this.getItemBySlot(EquipmentSlot.CHEST).is(Items.ELYTRA) ||
                     this.getItemBySlot(EquipmentSlot.CHEST).getDamageValue() > this.getItemBySlot(EquipmentSlot.CHEST).getMaxDamage() - 10)
                 {
-                    this.autoSwitchElytraChestplate = this.getItemBySlot(EquipmentSlot.CHEST);
+                    this.autoSwitchElytraChestplate = this.getItemBySlot(EquipmentSlot.CHEST).copy();
                     InventoryUtils.equipBestElytra(this);
                 }
             }
@@ -155,12 +155,14 @@ public abstract class MixinClientPlayerEntity extends AbstractClientPlayer
                             if (targetSlot >= 0)
                             {
                                 InventoryUtils.swapItemToEquipmentSlot(this, EquipmentSlot.CHEST, targetSlot);
-                                this.autoSwitchElytraChestplate = ItemStack.EMPTY;
-                            } else {
+                            }
+                            else
+                            {
                                 // cached item not found, try to swap to the default chest plate.
                                 InventoryUtils.swapElytraAndChestPlate(this);
-                                this.autoSwitchElytraChestplate = ItemStack.EMPTY;
                             }
+
+                            this.autoSwitchElytraChestplate = ItemStack.EMPTY;
                         }
                     }
                     else


### PR DESCRIPTION
I haven't touched Java or Minecraft modding for a long time so apologies if I've gotten this all wrong. But I'm pretty sure this was always defaulting to the fallback behaviour. autoSwitchElytraChestplate didn't seem to be getting set anywhere in the codebase from what I could see.