### PR TITLE
fix(tweakRepairMode): prevent swap spam and handle swapping slot 0.

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/util/InventoryUtils.java
@@ -1197,6 +1197,7 @@ public class InventoryUtils
         if (slotNum == -1) { return; }
         ItemStack stack = player.getItemBySlot(type);
 
+        // Fully repaired items in slot should be swapped with damaged items with mending
         if (stack.isEmpty() == false && (stack.isDamageableItem() == false || stack.isDamaged() == false || EquipmentUtils.getEnchantmentLevel(stack, Enchantments.MENDING) <= 0))
         {
             Slot slot = player.containerMenu.getSlot(slotNum);
@@ -1219,7 +1220,7 @@ public class InventoryUtils
 
         for (Slot slot : containerPlayer.slots)
         {
-            if (slot.hasItem() && isConfiguredRepairSlot(slot.index, player) == false)
+            if (slot.hasItem() && isConfiguredRepairSlot(slot.index, player) == false && slot.mayPlace(targetSlot.getItem()))
             {
                 ItemStack stack = slot.getItem();
 
@@ -1506,9 +1507,14 @@ public class InventoryUtils
     {
         Minecraft mc = Minecraft.getInstance();
         AbstractContainerMenu container = player.containerMenu;
-        mc.gameMode.handleContainerInput(container.containerId, slotNum, 0, ContainerInput.SWAP, player);
-        mc.gameMode.handleContainerInput(container.containerId, otherSlot, 0, ContainerInput.SWAP, player);
-        mc.gameMode.handleContainerInput(container.containerId, slotNum, 0, ContainerInput.SWAP, player);
+
+        int hotbarSlot = 0;
+        while (36 + hotbarSlot == slotNum || 36 + hotbarSlot == otherSlot) {
+            ++hotbarSlot;
+        }
+        mc.gameMode.handleContainerInput(container.containerId, slotNum, hotbarSlot, ContainerInput.SWAP, player);
+        mc.gameMode.handleContainerInput(container.containerId, otherSlot, hotbarSlot, ContainerInput.SWAP, player);
+        mc.gameMode.handleContainerInput(container.containerId, slotNum, hotbarSlot, ContainerInput.SWAP, player);
     }
 
     private static void swapToolToHand(int slotNumber, Minecraft mc)

--- a/src/main/resources/assets/tweakeroo/lang/en_us.json
+++ b/src/main/resources/assets/tweakeroo/lang/en_us.json
@@ -229,7 +229,7 @@
     "tweakeroo.config.feature_toggle.comment.tweakRenderEdgeChunks": "Allows the edge-most client-loaded chunks to render.\nVanilla doesn't allow rendering chunks that don't have\nall the adjacent chunks loaded, meaning that the edge-most chunk\nof the client's loaded won't render in vanilla.\n§lThis is also very helpful in the Free Camera mode!§r",
     "tweakeroo.config.feature_toggle.comment.tweakRenderInvisibleEntities": "When enabled, invisible entities are rendered like\nthey would be in spectator mode.",
     "tweakeroo.config.feature_toggle.comment.tweakRenderLimitEntities": "Enables limiting the number of certain types of entities\nto render per frame. Currently XP Orbs and Item entities\nare supported, see Generic configs for the limits.",
-    "tweakeroo.config.feature_toggle.comment.tweakRepairMode": "If enabled, then fully repaired items held in hand will\nbe swapped to damaged items that have Mending on them.",
+    "tweakeroo.config.feature_toggle.comment.tweakRepairMode": "If enabled, then fully repaired items in the slots configured in Lists -> repairModeSlots\nwill be swapped to damaged items that have Mending on them.",
     "tweakeroo.config.feature_toggle.comment.tweakScaffoldPlace": "Enables placing blocks as if they were scaffolding.\nSet the max distance in Generic -> scaffoldPlaceDistance\nWritten by Andrew54757 under TweakFork",
     "tweakeroo.config.feature_toggle.comment.tweakSculkPulseLength": "Allows modifying the Sculk Sensor pulse length. Set the pulse length in Generic -> sculkSensorPulseLength",
     "tweakeroo.config.feature_toggle.comment.tweakSelectiveBlocksRenderOutline": "Renders an outline over listed blocks\nWritten by Andrew54757 under TweakFork",


### PR DESCRIPTION
Fix two small bugs
1. In `swapSlots`, if slotNum or otherSlot corresponds to the 1st hotbar slot (0), then the swap fails. Check for a hotbar slot that isn't occupied by either.
   - Using `36` because the rest of the code assumes this is in the player inventory container (?). Repair mode swaps are only activated there at least.
3. In `findRepairableItemNotInRepairableSlot`, check that the target slot can also accept the item for the swap.
   - E.g. slot is helmet, targetSlot has pickaxe. Then helmet -> slot 0 fails, pickaxe -> slot 0, helmet -> slot 0 fails again. This just causes pickaxe and slot 0 to swap repeatedly, until all armor is repaired.
   - This check stops the spam, but it does mean it won't take off repaired armor, unless the armor slot is added to the repair list (and that swap works).
4. Update comment on tweakRepairMode