### PR TITLE
fix: hand restock swapping to empty slot

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
@@ -795,7 +795,7 @@ public class PlacementTweaks
             int threshold = Configs.Generic.HAND_RESTOCK_PRE_THRESHOLD.getIntegerValue();
 
             if (stackOriginal.isEmpty() == false && player.getInventory().getSelectedSlot() == hotbarSlot &&
-                (stackCurrent.isEmpty() || ItemStack.isSameItem(stackCurrent, stackOriginal) == false) || (Configs.Generic.HAND_RESTOCK_PRE.getBooleanValue() && stackCurrent.isEmpty() == false && stackCurrent.getCount() <= threshold && stackCurrent.getMaxStackSize() > threshold))
+                ((stackCurrent.isEmpty() || ItemStack.isSameItem(stackCurrent, stackOriginal) == false) || (Configs.Generic.HAND_RESTOCK_PRE.getBooleanValue() && stackCurrent.isEmpty() == false && stackCurrent.getCount() <= threshold && stackCurrent.getMaxStackSize() > threshold)))
             {
                 // Don't allow taking stacks from elsewhere in the hotbar, if the cycle tweak is on
                 boolean allowHotbar = FeatureToggle.TWEAK_HOTBAR_SLOT_CYCLE.getBooleanValue() == false &&


### PR DESCRIPTION
fixes #243 

Yea so I accidentally introduced that bug with a logic error in an if statement.