### PR TITLE
fix: avoid overwriting replaced freecam input

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/freecam/MixinLocalPlayer_freeCam.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/freecam/MixinLocalPlayer_freeCam.java
@@ -48,7 +48,11 @@ public abstract class MixinLocalPlayer_freeCam extends AbstractClientPlayer
     {
         if (this.realInput != null)
         {
-            this.input = this.realInput;
+            if (this.input == this.dummyMovementInput)
+            {
+                this.input = this.realInput;
+            }
+
             this.realInput = null;
         }
     }


### PR DESCRIPTION
When free camera suppresses player movement, only restore the saved input if Tweakaroo's dummy input is still installed.

This avoids overwriting input replacements made by other mods during the same tick. In particular, overlapping Tweakaroo's Freecam with other mods that disable camera-controls no longer risks leaving the player with an empty input handler after both are disabled.